### PR TITLE
[Fix] Update request due to github changes

### DIFF
--- a/src/Decoders.re
+++ b/src/Decoders.re
@@ -17,7 +17,7 @@ module GitHubGraphQLAPI = {
 
   let decodeResponseExn = json =>
     at(
-      ["data", "organization", "members"],
+      ["data", "organization", "membersWithRole"],
       field("edges", list(edge)),
       json,
     );

--- a/src/components/Awesome.re
+++ b/src/components/Awesome.re
@@ -134,7 +134,7 @@ let make = () => {
       Js.Json.string(
         "{
           organization(login:\"nativesintech\"){
-            members(first: 100) {
+            membersWithRole(first: 100) {
               edges {
                 node {
                   ...on User {


### PR DESCRIPTION
## Summary

Part of GitHub's API changed. Instead of `members`, the query should be `membersWithRole`. Subsequently, I needed to update my decoder to decode the response at `membersWithRole` instead of `members`. 

## Issue

#51 